### PR TITLE
A new approach to fallback configuration.

### DIFF
--- a/jackal_base/CMakeLists.txt
+++ b/jackal_base/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED COMPONENTS thread)
 
 catkin_package()
+catkin_add_env_hooks(50.jackal_find_mag_config
+  SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 

--- a/jackal_base/config/mag_config_default.yaml
+++ b/jackal_base/config/mag_config_default.yaml
@@ -1,3 +1,4 @@
+use_mag: false
 mag_bias_x: 0
 mag_bias_y: 0
 mag_bias_z: 0

--- a/jackal_base/env-hooks/50.jackal_find_mag_config.sh
+++ b/jackal_base/env-hooks/50.jackal_find_mag_config.sh
@@ -1,0 +1,6 @@
+JACKAL_MAG_CONFIG=$(catkin_find --etc --first-only jackal_base mag_config.yaml)
+if [ -z "$JACKAL_MAG_CONFIG" ]; then
+  JACKAL_MAG_CONFIG=$(catkin_find --share --first-only jackal_base config/mag_config_default.yaml)
+fi
+
+export JACKAL_MAG_CONFIG

--- a/jackal_base/env-hooks/50.jackal_find_mag_config.sh
+++ b/jackal_base/env-hooks/50.jackal_find_mag_config.sh
@@ -1,6 +1,6 @@
-JACKAL_MAG_CONFIG=$(catkin_find --etc --first-only jackal_base mag_config.yaml)
+JACKAL_MAG_CONFIG=$(catkin_find --etc --first-only jackal_base mag_config.yaml 2>/dev/null)
 if [ -z "$JACKAL_MAG_CONFIG" ]; then
-  JACKAL_MAG_CONFIG=$(catkin_find --share --first-only jackal_base config/mag_config_default.yaml)
+  JACKAL_MAG_CONFIG=$(catkin_find --share --first-only jackal_base config/mag_config_default.yaml 2>/dev/null)
 fi
 
 export JACKAL_MAG_CONFIG

--- a/jackal_base/launch/base.launch
+++ b/jackal_base/launch/base.launch
@@ -23,13 +23,15 @@
 
   <!-- Filter raw gyro data into a usable IMU message -->
   <node pkg="imu_filter_madgwick" type="imu_filter_node" name="imu_filter">
+    <!-- This environment variable is populated by an env hook in the jackal_base
+         package. It looks for a user-generated mag config (eg, from running
+         the calibrate_compass script), and falls back on a default one. -->
+    <rosparam file="$(env JACKAL_MAG_CONFIG)" />
     <rosparam>
       gain: 0.1
       zeta: 0.001
-      use_mag: true
       publish_tf: false
     </rosparam>
-    <rosparam file="/etc/ros/$(env ROS_DISTRO)/ros.d/imu_compass.yaml" />
   </node> 
 
   <!-- Differential controller and basic localization -->

--- a/jackal_base/scripts/calibrate_compass
+++ b/jackal_base/scripts/calibrate_compass
@@ -3,7 +3,7 @@
 TEMPDIR=$(mktemp -d --tmpdir calibrate_compass.XXXX)
 BAG_FILE=${TEMPDIR}/imu_record.bag
 CAL_FILE=${TEMPDIR}/mag_config.yaml
-CAL_FINAL_PATH=${ROS_ETC_DIR}/jackal_base
+CAL_FINAL_PATH=${ROS_ETC_DIR%/*}/jackal_base
 DURATION=60
 
 ROSTOPIC_OUTPUT=$(rostopic list)

--- a/jackal_base/scripts/calibrate_compass
+++ b/jackal_base/scripts/calibrate_compass
@@ -2,7 +2,8 @@
 
 TEMPDIR=$(mktemp -d --tmpdir calibrate_compass.XXXX)
 BAG_FILE=${TEMPDIR}/imu_record.bag
-CAL_FILE=${TEMPDIR}/imu_compass.yaml
+CAL_FILE=${TEMPDIR}/mag_config.yaml
+CAL_FINAL_PATH=${ROS_ETC_DIR}/jackal_base
 DURATION=60
 
 ROSTOPIC_OUTPUT=$(rostopic list)
@@ -55,12 +56,13 @@ fi
 
 if [[ -r $CAL_FILE ]]; then
   echo "Calibration generated in $CAL_FILE."
-  read -r -p "Copy calibration to /etc/ros/${ROS_DISTRO}? [Y/n] " response
+  read -r -p "Copy calibration to ${CAL_FINAL_PATH}? [Y/n] " response
   response=${response,,}    # tolower
   if [[ $response =~ ^(no|n)$ ]]; then
     echo "Skipping."
   else
-    sudo cp $CAL_FILE /etc/ros/${ROS_DISTRO}
+    sudo mkdir -p ${CAL_FINAL_PATH}
+    sudo cp $CAL_FILE ${CAL_FINAL_PATH}
     echo "Restart ROS service to begin using saved calibration."
   fi
 fi

--- a/jackal_base/scripts/compute_calibration
+++ b/jackal_base/scripts/compute_calibration
@@ -125,6 +125,7 @@ print("Magnetic circle centered at " + str(center) + ", with radius " + str(radi
 
 with open(args.outfile, "w") as f:
   f.write("# Generated from %s on %s.\n" % (args.bag, datetime.date.today()))
+  f.write("use_mag: true\n")
   f.write("mag_bias_x: %f\n" % center[0])
   f.write("mag_bias_y: %f\n" % center[1])
   f.write("mag_bias_z: %f\n" % center[2])

--- a/jackal_base/scripts/compute_calibration
+++ b/jackal_base/scripts/compute_calibration
@@ -25,7 +25,7 @@ try:
 except ImportError:
   pyplot = None
 
-parser = ArgumentParser(description='Process bag file for compass calibration. Pass a bag containing /imu/rpy/raw and /imu/mag topics, with the compass facing upright, being slowly rotated in a clockwise direction for 30-120 seconds.')
+parser = ArgumentParser(description='Process bag file for compass calibration. Pass a bag containing /imu/mag topic, with the compass facing upright, being slowly rotated in a clockwise direction for 30-120 seconds.')
 parser.add_argument('bag', metavar='FILE', type=str, help='input bag file')
 parser.add_argument('outfile', metavar='OUTFILE', type=str, help='output yaml file',
                     nargs="?", default="/tmp/calibration.yaml")
@@ -36,69 +36,12 @@ if not args.plots:
     pyplot = None
 
 bag = rosbag.Bag(args.bag)
-imu_rot = Quaternion(0,0,0,1) 
-transform_found = False
-for topic, msg, time in bag.read_messages(topics=("/tf", "/tf")):
-        for c_trans in msg.transforms:
-		if ("base_link" in c_trans.header.frame_id and "imu_link" in c_trans.child_frame_id):
-			imu_rot = c_trans.transform.rotation
-			transform_found = True
-			break
-	if (transform_found):
-		break
-
-temp_q = (imu_rot.x, imu_rot.y, imu_rot.z, imu_rot.w)
-imu_rot = temp_q
-t_array = quaternion_matrix(imu_rot)
-t_mat = matrix(t_array)
-t_mat = t_mat.I
-
-if (not transform_found):
-	print("Transform between base_link and imu_link not found, assuming unity")
-
-time_yaw_tuples = []
-for topic, msg, time in bag.read_messages(topics=("/imu/rpy/raw", "imu/rpy/raw")):	
-	o_msg = matrix([msg.vector.x, msg.vector.y, msg.vector.z, 0])
-	o_msg = o_msg.T
-	transformed_msg = t_mat*o_msg
-	time_yaw_tuples.append((time.to_sec(), float(transformed_msg[2])))
-	
-
-if len(time_yaw_tuples) < 100:
-  print("Insufficient data or no data in bag file. Looking for topic /imu/rpy/raw.")
-  exit(1)
-
-
-time_yaw = zip(*time_yaw_tuples)
-time_yaw.append(diff(time_yaw[-1]))
-time_yaw_tuples_filtered = [tup for tup in zip(*time_yaw) if abs(tup[-1]) < 3.0]
-time_yaw = zip(*time_yaw_tuples_filtered)
-# apply smoothing as a new column
-w = [1.0 / 30.0] * 30
-time_yaw.append(convolve(time_yaw[-1], w, 'same'))
-
-# remove sections of no movement.
-time_yaw_tuples_movement = [tup for tup in zip(*time_yaw)] # if abs(tup[-1]) > 0.01]
-time_start = time_yaw_tuples_movement[50][0]
-time_end = time_yaw_tuples_movement[-50][0]
-
-if pyplot:
-  fig = pyplot.figure()
-  ax1 = fig.add_subplot(211)
-  ax1.scatter(array(time_yaw[0]), time_yaw[-1])
-  lines = pyplot.axvline(time_start)
-  pyplot.axvline(time_end)
-  fig.gca().add_artist(lines)
 
 vecs = []
-for topic, msg, time in bag.read_messages(topics=("/imu/mag", "imu/mag")):
-  if time.to_sec() > time_start and time.to_sec() < time_end:
-	o_msg = matrix([msg.vector.x, msg.vector.y, msg.vector.z, 0])
-	o_msg = o_msg.T
-	t_msg = t_mat*o_msg
-	vecs.append((float(t_msg[0]), float(t_msg[1]), float(t_msg[2])))
+for topic, msg, time in bag.read_messages(topics=("/imu/mag",)):
+  vecs.append((float(msg.vector.x), float(msg.vector.y), float(msg.vector.z)))
 
-print ("Using data from " + str(time_start) +" to " + str (time_end) + "(" + str(time_end - time_start) + " seconds), or " + str(len(vecs)) + " samples.")
+print ("Using " + str(len(vecs)) + " samples.")
 
 def calc_R(xc, yc):
     """ calculate the distance of each 2D points from the center (xc, yc) """
@@ -126,9 +69,9 @@ print("Magnetic circle centered at " + str(center) + ", with radius " + str(radi
 with open(args.outfile, "w") as f:
   f.write("# Generated from %s on %s.\n" % (args.bag, datetime.date.today()))
   f.write("use_mag: true\n")
-  f.write("mag_bias_x: %f\n" % center[0])
-  f.write("mag_bias_y: %f\n" % center[1])
-  f.write("mag_bias_z: %f\n" % center[2])
+  f.write("mag_bias_x: {:.9f}\n".format(center[0]))
+  f.write("mag_bias_y: {:.9f}\n".format(center[1]))
+  f.write("mag_bias_z: {:.9f}\n".format(center[2]))
 
 print("Calibration file written to " + args.outfile)
 


### PR DESCRIPTION
I've never been satisfied with the approach to IMU calibration we used on the Hydro platform software, of hard-coding absolute paths into package launch files, eg: https://github.com/husky/husky_bringup/blob/hydro-devel/launch/navsat_config/compass.launch#L3

I think I like the approach in this PR a lot better—the decision which configuration file to use is being made at setup time, so the hook is able to intelligently select between a user-generated config and a default/fallback one. I think this approach could be broadly applicable to any situation where we're wanting to funnel user-generated content from ROS into successive roslaunch invocations. (think saved maps, control constants, ekf configs, etc)

A future rewrite of the calibration script from bash to python could allow further control by the user (for example, allowing them to place the calibration in their overlay's etc folder, and not user sudo, rather than having to put it in `$ROS_ETC_DIR`, as root.

I  need to try this out on RG's Jackal tomorrow to just confirm that everything does what it's supposed to, so please don't merge.

Review: @paulbovbel, @rgariepy
