### PR TITLE
Small fixes revealed in testing on live hardware

### DIFF
--- a/jackal_bringup/debian/udev
+++ b/jackal_bringup/debian/udev
@@ -6,6 +6,7 @@ KERNEL=="js*", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c21f", SYMLINK="input
 
 # Udev rule for the PS4 controller
 KERNEL=="js*", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="07dc", SYMLINK="input/ps4"
+KERNEL=="js*", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="07da", SYMLINK="input/ps4"
 
 # Alternate Udev rule for the PS4 controller (if it's detected as DualShock 4)
 KERNEL=="js*", ATTRS{idVendor}=="054C", ATTRS{idProduct}=="05C4", SYMLINK="input/ps4"

--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -16,7 +16,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
     </group>
     <group if="$(optenv JACKAL_LASER_HOKUYO 0)">
       <node pkg="urg_node" name="hokuyo" type="urg_node">
-        <param name="_ip_address" value="$(optenv JACKAL_LASER_HOST 192.168.131.20)" />
+        <param name="ip_address" value="$(optenv JACKAL_LASER_HOST 192.168.131.20)" />
         <param name="frame_id" value="$(optenv JACKAL_LASER_MOUNT front)_laser" />
         <remap from="scan" to="$(optenv JACKAL_LASER_TOPIC front/scan)" />
       </node>


### PR DESCRIPTION
The IP address parameter for the Hokuyo lidar was incorrect, and the udev rules for the PS4 controller needed updating.