### PR TITLE
Add groups for the front/rear fender lasers' nodes

### DIFF
--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -23,6 +23,26 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
     </group>
   </group>
 
+  <!-- Optional front/rear UST-10 lidars mounted to the accessory fenders -->
+  <group if="$(optenv JACKAL_FRONT_ACCESSORY_FENDER 0)">
+    <group if="$(optenv JACKAL_FRONT_FENDER_UST10 0)">
+      <node pkg="urg_node" name="front_fender_hokuyo" type="urg_node">
+        <param name="ip_address" value="$(optenv JACKAL_FRONT_LASER_HOST 192.168.131.20)" />
+        <param name="frame_id" value="front_fender_accessory_link_laser" />
+        <remap from="scan" to="$(optenv JACKAL_FRONT_LASER_TOPIC front/scan)" />
+      </node>
+    </group>
+  </group>
+  <group if="$(optenv JACKAL_REAR_ACCESSORY_FENDER 0)">
+    <group if="$(optenv JACKAL_REAR_FENDER_UST10 0)">
+      <node pkg="urg_node" name="rear_fender_hokuyo" type="urg_node">
+        <param name="ip_address" value="$(optenv JACKAL_REAR_LASER_HOST 192.168.131.21)" />
+        <param name="frame_id" value="rear_fender_accessory_link_laser" />
+        <remap from="scan" to="$(optenv JACKAL_REAR_LASER_TOPIC rear/scan)" />
+      </node>
+    </group>
+  </group>
+
   <!-- Optional Point Grey Bumblebee2 camera, typically front-facing. -->
   <group if="$(optenv JACKAL_BB2 0)" ns="camera">
     <node pkg="nodelet" type="nodelet" name="bumblebee2_nodelet_manager" args="manager" />


### PR DESCRIPTION
It looks like the optional UST-10 lidars are not actually launched anywhere, so add the nodes to the accessories launch file