### PR TITLE
Add VLP16 support, refactor main/secondary laser envar support

### DIFF
--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -6,7 +6,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
 -->
 <launch>
   <!--
-    Primary and secondary 2D lasers.  Model defined by JACKAL_LASER_MODEL and JACKAL_LASER2_MODEL.
+    Primary and secondary 2D lasers.  Model defined by JACKAL_LASER_MODEL and JACKAL_LASER_SECONDARY_MODEL.
     Valid models:
       - lms1xx (default)  :: SICK LMS1xx
       - ust10             :: Hokuyo UST10
@@ -28,20 +28,20 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
       </node>
     </group>
   </group>
-  <group if="$(optenv JACKAL_LASER2 0)">
-    <arg name="lidar2_model" value="$(optenv JACKAL_LASER2_MODEL lms1xx)" />
+  <group if="$(optenv JACKAL_LASER_SECONDARY 0)">
+    <arg name="lidar2_model" value="$(optenv JACKAL_LASER_SECONDARY_MODEL lms1xx)" />
     <group if="$(eval arg('lidar2_model') == 'lms1xx')">
       <node pkg="lms1xx" name="lms1xx_2" type="LMS1xx_node">
-        <param name="host" value="$(optenv JACKAL_LASER2_HOST 192.168.131.21)" />
-        <param name="frame_id" value="$(optenv JACKAL_LASER2_MOUNT rear)_laser" />
-        <remap from="scan" to="$(optenv JACKAL_LASER2_TOPIC rear/scan)" />
+        <param name="host" value="$(optenv JACKAL_LASER_SECONDARY_HOST 192.168.131.21)" />
+        <param name="frame_id" value="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)_laser" />
+        <remap from="scan" to="$(optenv JACKAL_LASER_SECONDARY_TOPIC rear/scan)" />
       </node>
     </group>
     <group if="$(eval arg('lidar2_model') == 'ust10')">
       <node pkg="urg_node" name="hokuyo_2" type="urg_node">
-        <param name="ip_address" value="$(optenv JACKAL_LASER2_HOST 192.168.131.21)" />
-        <param name="frame_id" value="$(optenv JACKAL_LASER2_RPY_MOUNT rear)_laser" />
-        <remap from="scan" to="$(optenv JACKAL_LASER2_TOPIC rear/scan)" />
+        <param name="ip_address" value="$(optenv JACKAL_LASER_SECONDARY_HOST 192.168.131.21)" />
+        <param name="frame_id" value="$(optenv JACKAL_LASER_SECONDARY_RPY_MOUNT rear)_laser" />
+        <remap from="scan" to="$(optenv JACKAL_LASER_SECONDARY_TOPIC rear/scan)" />
       </node>
     </group>
   </group>

--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -28,7 +28,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
     <group if="$(optenv JACKAL_FRONT_FENDER_UST10 0)">
       <node pkg="urg_node" name="front_fender_hokuyo" type="urg_node">
         <param name="ip_address" value="$(optenv JACKAL_FRONT_LASER_HOST 192.168.131.20)" />
-        <param name="frame_id" value="front_fender_accessory_link_laser" />
+        <param name="frame_id" value="front_laser" />
         <remap from="scan" to="$(optenv JACKAL_FRONT_LASER_TOPIC front/scan)" />
       </node>
     </group>
@@ -37,7 +37,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
     <group if="$(optenv JACKAL_REAR_FENDER_UST10 0)">
       <node pkg="urg_node" name="rear_fender_hokuyo" type="urg_node">
         <param name="ip_address" value="$(optenv JACKAL_REAR_LASER_HOST 192.168.131.21)" />
-        <param name="frame_id" value="rear_fender_accessory_link_laser" />
+        <param name="frame_id" value="rear_laser" />
         <remap from="scan" to="$(optenv JACKAL_REAR_LASER_TOPIC rear/scan)" />
       </node>
     </group>

--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -23,6 +23,26 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
     </group>
   </group>
 
+  <!-- Optional front/rear UST-10 lidars mounted to the accessory fenders -->
+  <group if="$(optenv JACKAL_FRONT_ACCESSORY_FENDER 0)">
+    <group if="$(optenv JACKAL_FRONT_FENDER_UST10 0)">
+      <node pkg="urg_node" name="front_fender_hokuyo" type="urg_node">
+        <param name="ip_address" value="$(optenv JACKAL_FRONT_LASER_HOST 192.168.131.20)" />
+        <param name="frame_id" value="front_fender_accessory_link_laser" />
+        <remap from="scan" to="$(optenv JACKAL_FRONT_LASER_TOPIC front/scan)" />
+      </node>
+    </group>
+  </group>
+  <group if="$(optenv JACKAL_REAR_ACCESSORY_FENDER 0)">
+    <group if="$(optenv JACKAL_REAR_FENDER_UST10 0)">
+      <node pkg="urg_node" name="rear_fender_hokuyo" type="urg_node">
+        <param name="ip_address" value="$(optenv JACKAL_REAR_LASER_HOST 192.168.131.21)" />
+        <param name="frame_id" value="rear_fender_accessory_link_laser" />
+        <remap from="scan" to="$(optenv JACKAL_REAR_LASER_TOPIC rear/scan)" />
+      </node>
+    </group>
+  </group>
+
   <!-- Optional Point Grey Bumblebee2 camera, typically front-facing. -->
   <group if="$(optenv JACKAL_BB2 0)" ns="camera">
     <node pkg="nodelet" type="nodelet" name="bumblebee2_nodelet_manager" args="manager" />

--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -72,7 +72,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
       <arg name="lidar_3d_model" value="$(optenv JACKAL_LASER_3D_MODEL vlp16)" />
       <include file="$(find velodyne_pointcloud)/launch/VLP-16.launch">
         <arg name="device_ip" value="$(optenv JACKAL_LASER_3D_HOST 192.168.131.20)" />
-        <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC front/points)" />
+        <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC mid/points)" />
       </include>
     </group>
   </group>

--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -5,20 +5,43 @@ Be careful that the defaults in this file are kept aligned with those
 in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
 -->
 <launch>
-  <!-- Primary LMS1xx-series LIDAR, typically front-facing. -->
+  <!--
+    Primary and secondary 2D lasers.  Model defined by JACKAL_LASER_MODEL and JACKAL_LASER2_MODEL.
+    Valid models:
+      - lms1xx (default)  :: SICK LMS1xx
+      - ust10             :: Hokuyo UST10
+  -->
   <group if="$(optenv JACKAL_LASER 0)">
-    <group unless="$(optenv JACKAL_LASER_HOKUYO 0)">
+    <arg name="lidar_model" value="$(optenv JACKAL_LASER_MODEL lms1xx)" />
+    <group if="$(eval arg('lidar_model') == 'lms1xx')">
       <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
         <param name="host" value="$(optenv JACKAL_LASER_HOST 192.168.131.20)" />
         <param name="frame_id" value="$(optenv JACKAL_LASER_MOUNT front)_laser" />
         <remap from="scan" to="$(optenv JACKAL_LASER_TOPIC front/scan)" />
       </node>
     </group>
-    <group if="$(optenv JACKAL_LASER_HOKUYO 0)">
+    <group if="$(eval arg('lidar_model') == 'ust10')">
       <node pkg="urg_node" name="hokuyo" type="urg_node">
         <param name="ip_address" value="$(optenv JACKAL_LASER_HOST 192.168.131.20)" />
         <param name="frame_id" value="$(optenv JACKAL_LASER_MOUNT front)_laser" />
         <remap from="scan" to="$(optenv JACKAL_LASER_TOPIC front/scan)" />
+      </node>
+    </group>
+  </group>
+  <group if="$(optenv JACKAL_LASER2 0)">
+    <arg name="lidar2_model" value="$(optenv JACKAL_LASER2_MODEL lms1xx)" />
+    <group if="$(eval arg('lidar2_model') == 'lms1xx')">
+      <node pkg="lms1xx" name="lms1xx_2" type="LMS1xx_node">
+        <param name="host" value="$(optenv JACKAL_LASER2_HOST 192.168.131.21)" />
+        <param name="frame_id" value="$(optenv JACKAL_LASER2_MOUNT rear)_laser" />
+        <remap from="scan" to="$(optenv JACKAL_LASER2_TOPIC rear/scan)" />
+      </node>
+    </group>
+    <group if="$(eval arg('lidar2_model') == 'ust10')">
+      <node pkg="urg_node" name="hokuyo_2" type="urg_node">
+        <param name="ip_address" value="$(optenv JACKAL_LASER2_HOST 192.168.131.21)" />
+        <param name="frame_id" value="$(optenv JACKAL_LASER2_RPY_MOUNT rear)_laser" />
+        <remap from="scan" to="$(optenv JACKAL_LASER2_TOPIC rear/scan)" />
       </node>
     </group>
   </group>
@@ -40,6 +63,17 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
         <param name="frame_id" value="rear_laser" />
         <remap from="scan" to="$(optenv JACKAL_REAR_LASER_TOPIC rear/scan)" />
       </node>
+    </group>
+  </group>
+
+  <!-- Optional 3D lidar -->
+  <group if="$(optenv JACKAL_LASER_3D 0)">
+    <group if="$(eval arg('lidar_3d_model') == 'vlp16')">
+      <arg name="lidar_3d_model" value="$(optenv JACKAL_LASER_3D_MODEL vlp16)" />
+      <include file="$(find velodyne_pointcloud)/launch/VLP-16.launch">
+        <arg name="device_ip" value="$(optenv JACKAL_LASER_3D_HOST 192.168.131.20)" />
+        <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC front/points)" />
+      </include>
     </group>
   </group>
 

--- a/jackal_bringup/package.xml
+++ b/jackal_bringup/package.xml
@@ -14,6 +14,7 @@
   <run_depend version_gte="0.3">jackal_base</run_depend>
   <run_depend>lms1xx</run_depend>
   <run_depend>urg_node</run_depend>
+  <run_depend>velodyne_pointcloud</run_depend>
   <!-- Temporarily removed until the driver is built properly again -->
   <run_depend>pointgrey_camera_driver</run_depend>
   <run_depend>nmea_comms</run_depend>


### PR DESCRIPTION
This depends on a similar PR in jackal_description

Main features:
- remove JACKAL_LASER_HOKUYO, replace with Dingo-style JACKAL_LASER_TYPE
- add JACKAL_LASER2 for mounting a secondary laser without using the accessory fenders
- add JACKAL_LASER_3D for mounting a primary 3D lidar