### PR TITLE
Fix Windows build

### DIFF
--- a/jackal_base/src/jackal_base.cpp
+++ b/jackal_base/src/jackal_base.cpp
@@ -31,6 +31,10 @@
  *
  */
 
+#include <ros/ros.h>
+#include <controller_manager/controller_manager.h>
+#include <rosserial_server/serial_session.h>
+
 #include <string>
 
 #if defined(_WIN32)
@@ -46,10 +50,6 @@
 // #if defined(_WIN32) && defined(ERROR)
 // #undef ERROR
 // #endif
-
-#include <controller_manager/controller_manager.h>
-#include <ros/ros.h>
-#include <rosserial_server/serial_session.h>
 
 #include "jackal_base/jackal_diagnostic_updater.h"
 #include "jackal_base/jackal_hardware.h"


### PR DESCRIPTION
Boost includes Windows headers which have defines which conflict with ROS. Reordered the headers so that they do not conflict. 