### PR TITLE
WIP - Use official Microstrain driver

### DIFF
--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -212,7 +212,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
 
   <!-- Optional GX5 family IMU -->
   <group if="$(optenv JACKAL_GX5_IMU 0)">
-    <include file="$(find ros_mscl)/launch/microstrain.launch">
+    <include file="$(find microstrain_inertial_driver)/launch/microstrain.launch">
       <arg name="imu_frame_id"  value="gx5_link" />
       <arg name="port"          value="$(optenv JACKAL_GX5_IMU_PORT /dev/microstrain)" />
       <arg name="use_enu_frame" value="true" />

--- a/jackal_bringup/package.xml
+++ b/jackal_bringup/package.xml
@@ -11,16 +11,16 @@
   <url type="website">http://wiki.ros.org/Robots/Jackal</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  
   <run_depend version_gte="0.3">jackal_base</run_depend>
   <run_depend>lms1xx</run_depend>
-  <run_depend>urg_node</run_depend>
-  <run_depend>velodyne_pointcloud</run_depend>
-  <!-- Temporarily removed until the driver is built properly again -->
-  <run_depend>pointgrey_camera_driver</run_depend>
+  <run_depend>microstrain_inertial_driver</run_depend>
   <run_depend>nmea_comms</run_depend>
   <run_depend>nmea_navsat_driver</run_depend>
+  <run_depend>pointgrey_camera_driver</run_depend>
   <run_depend version_gte="0.1.1">robot_upstart</run_depend>
-  <run_depend>microstrain_inertial_driver</run_depend>
+  <run_depend>urg_node</run_depend>
+  <run_depend>velodyne_pointcloud</run_depend>
 
   <export>
   </export>

--- a/jackal_bringup/package.xml
+++ b/jackal_bringup/package.xml
@@ -20,7 +20,7 @@
   <run_depend>nmea_comms</run_depend>
   <run_depend>nmea_navsat_driver</run_depend>
   <run_depend version_gte="0.1.1">robot_upstart</run_depend>
-  <run_depend>ros_mscl</run_depend>
+  <run_depend>microstrain_inertial_driver</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
LORD has released the former `ros_mscl` driver under the name `microstrain_inertial_driver`.  Switch the accessories to use the official driver instead of our interim fork.
This PR is marked as WIP until we have the chance to test the sensor on the robot to make sure everything works correctly before merging.