### PR TITLE
Use python3 for the install script

### DIFF
--- a/jackal_bringup/scripts/install
+++ b/jackal_bringup/scripts/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import robot_upstart


### PR DESCRIPTION
Since removing python-is-python3 from the ISO this script appears to fail on a fresh Noetic install.