### PR TITLE
Change sensor_msgs/MagneticField member to magnetic_field instead of vector

### DIFF
--- a/jackal_base/scripts/compute_calibration
+++ b/jackal_base/scripts/compute_calibration
@@ -39,7 +39,7 @@ bag = rosbag.Bag(args.bag)
 
 vecs = []
 for topic, msg, time in bag.read_messages(topics=("/imu/mag",)):
-  vecs.append((float(msg.vector.x), float(msg.vector.y), float(msg.vector.z)))
+  vecs.append((float(msg.magnetic_field.x), float(msg.magnetic_field.y), float(msg.magnetic_field.z)))
 
 print ("Using " + str(len(vecs)) + " samples.")
 


### PR DESCRIPTION
Running the `calibrate_compass` node from the `jackal_base` package results in an attribute error. The `calibrate_compass` node calls the `compute_calibration` script, which references a member `vector` that does not exist in the `sensor_msgs/MagneticField` message, when reading messages from the `/imu/mag` topic.

The `/imu/mag` topic provides messages of `sensor_msgs/MagneticField` type. Looking at this message, we can see that that it has three members, none of which is called `vector`. However, the `magnetic_field` member is of type `geometry_msgs/Vector3`. Changing the attribute `vector` to `magnetic_field` results in the script working as expected.