### PR TITLE
Moved Remap out of Include

### DIFF
--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -89,7 +89,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
         <remap from="scan" to="$(optenv JACKAL_FRONT_LASER_TOPIC front/scan)" />
       </node>
     </group>
-  </group>remap
+  </group>
   <group if="$(optenv JACKAL_REAR_ACCESSORY_FENDER 0)">
     <group if="$(optenv JACKAL_REAR_FENDER_UST10 0)">
       <node pkg="urg_node" name="rear_fender_hokuyo" type="urg_node">

--- a/jackal_bringup/launch/accessories.launch
+++ b/jackal_bringup/launch/accessories.launch
@@ -65,15 +65,15 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
   <group if="$(optenv JACKAL_LASER_3D 0)">
     <arg name="lidar_3d_model" value="$(optenv JACKAL_LASER_3D_MODEL vlp16)" />
     <group if="$(eval arg('lidar_3d_model') == 'vlp16')">
+      <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC mid/points)" />
       <include file="$(find velodyne_pointcloud)/launch/VLP16_points.launch">
         <arg name="device_ip" value="$(optenv JACKAL_LASER_3D_HOST 192.168.131.20)" />
-        <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC mid/points)" />
       </include>
     </group>
     <group if="$(eval arg('lidar_3d_model') == 'hdl32e')">
+      <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC mid/points)" />
       <include file="$(find velodyne_pointcloud)/launch/32e_points.launch">
         <arg name="device_ip" value="$(optenv JACKAL_LASER_3D_HOST 192.168.131.20)" />
-        <remap from="velodyne_points" to="$(optenv JACKAL_LASER_3D_TOPIC mid/points)" />
       </include>
     </group>
   </group>
@@ -89,7 +89,7 @@ in the URDF. See jackal_description/urdf/accessories.urdf.xacro.
         <remap from="scan" to="$(optenv JACKAL_FRONT_LASER_TOPIC front/scan)" />
       </node>
     </group>
-  </group>
+  </group>remap
   <group if="$(optenv JACKAL_REAR_ACCESSORY_FENDER 0)">
     <group if="$(optenv JACKAL_REAR_FENDER_UST10 0)">
       <node pkg="urg_node" name="rear_fender_hokuyo" type="urg_node">


### PR DESCRIPTION
Remaps inside includes do not affect the nodes in the included file. Remaps at the same level of the include tag propagate to all nodes including those in the include. 